### PR TITLE
fix: sharing link from Easel NFT image link is not valid

### DIFF
--- a/default_settings.json
+++ b/default_settings.json
@@ -42,10 +42,11 @@
         },
         "coingeckoId": "cosmos",
         "networks": "https://gist.githubusercontent.com/kwunyeung/8be4598c77c61e497dfc7220a678b3ee/raw/bd-networks.json",
-        "banners": false
+        "banners": false,
+        "baseURL": "http://wallet.pylons.tech"
     },
     "remote":{
-        "rpc":"https://rpc.stargate.forbole.com:443",
+        "rpc":"https://rpc.stargate.forbole.com:443/",
         "api":"https://api.stargate.forbole.com:443"
     },
     "debug": {

--- a/imports/api/nfts/server/methods.js
+++ b/imports/api/nfts/server/methods.js
@@ -54,7 +54,7 @@ Meteor.methods({
                     
                     if (finishedNftIds.NO != -1 && !finishedNftIds.has(trade.itemOutputs[0].itemID)) {
                         try { 
-                            let response = HTTP.get("http://api.testnet.pylons.tech:1317/pylons/executions/item/" + trade.itemOutputs[0].cookbookID + '/' +  trade.itemOutputs[0].itemID);
+                            let response = HTTP.get(Meteor.settings.remote.api + "/pylons/executions/item/" + trade.itemOutputs[0].cookbookID + '/' +  trade.itemOutputs[0].itemID);
                             let executions = JSON.parse(response.content);
                             let item = executions.CompletedExecutions[0]
                             // let response = HTTP.get("https://api.testnet.pylons.tech/pylons/item/cookbook_for_test5/LQM2cdzDY3");
@@ -67,7 +67,7 @@ Meteor.methods({
                             item.NO = date.getFullYear() * 1000 * 360 * 24 * 30 * 12 + date.getMonth() * 1000 * 360 * 24 * 30 + date.getDay() * 1000 * 360 * 24 + date.getHours() * 1000 * 360 + date.getMinutes() * 1000 * 60 + date.getSeconds() * 1000 + date.getMilliseconds();
                             item.tradeable = true;
                             
-                            let resalelink = 'https://wallet.pylons.tech?action=resell_nft&recipe_id=' + item.recipeID + '&cookbook_id='+ nft.cookbookID + '&nft_amount=1';   
+                            let resalelink = Meteor.settings.public.baseURL + '?action=resell_nft&recipe_id=' + item.recipeID + '&cookbook_id='+ nft.cookbookID + '&nft_amount=1';
                             item.resalelink = resalelink; 
  
                             bulkNfts.find({ ID: item.ID }).upsert().updateOne({ $set: item });

--- a/imports/api/recipes/server/methods.js
+++ b/imports/api/recipes/server/methods.js
@@ -59,7 +59,7 @@ Meteor.methods({
 
                 for (let i in recipes) {
                     let recipe = recipes[i];
-                    let deeplink = 'https://wallet.pylons.tech?action=purchase_nft&recipe_id=' + recipe.ID + "&cookbook_id=" + recipe.cookbookID +  '&nft_amount=1';  
+                    let deeplink = Meteor.settings.public.baseURL + '?action=purchase_nft&recipe_id=' + recipe.ID + "&cookbook_id=" + recipe.cookbookID +  '&nft_amount=1';
                     recipe.deeplink = deeplink;
                     var cookbook_owner = "", creator = "";
                     try {   

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -55,24 +55,18 @@ Meteor.startup(() => {
         var img = ''; 
         var selectedRecipe = null;
         var recipes = null;  
-        if (querys['?action'] == "purchase_nft" && querys['recipe_id'] != null && querys['cookbook_id'] != null && querys['nft_amount'] == 1) { 
-            var selectedItem = null; 
-            const recipe_id = querys['recipe_id']    
-            let recipesUrl = Meteor.settings.remote.api + '/pylons/recipes/'
+        if (querys['?action'] == "purchase_nft" && querys['recipe_id'] != null && querys['cookbook_id'] != null && querys['nft_amount'] == 1) {
+            const recipe_id = querys['recipe_id']    ;
+            const cookbook_id = querys['cookbook_id']    ;
+            let recipesUrl =`${Meteor.settings.remote.api}/pylons/recipe/${cookbook_id}/${recipe_id}`;
 
             try { 
-                let response = HTTP.get(recipesUrl);    
-                recipes = JSON.parse(response.content).Recipes;   
+                let response = HTTP.get(recipesUrl);
+                selectedRecipe = JSON.parse(response.content).Recipe;
                 
             } catch (e) { 
                 console.log(e);
-            }   
-            for(i = 0; i < recipes.length; i++){
-                selectedRecipe = recipes[i];
-                if(selectedRecipe.ID == recipe_id){
-                    break;
-                }
-            }  
+            }
             
             if (selectedRecipe != undefined && selectedRecipe != null && selectedRecipe.entries.itemOutputs.length > 0) {                 
                 const strings = selectedRecipe.entries.itemOutputs[0].strings; 
@@ -225,22 +219,17 @@ Meteor.startup(() => {
             
         }  
         else if (querys['?action'] == "resell_nft" && querys['recipe_id'] != null /*&& querys['cookbook_id'] != null*/ && querys['nft_amount'] == 1) { 
-            var selectedItem = null; 
-            const recipe_id = querys['recipe_id']   
-            //const cookbook_id = querys['cookbook_id']     
+            const recipe_id = querys['recipe_id'];
+            const cookbook_id = querys['cookbook_id'];
+            let recipesUrl =`${Meteor.settings.remote.api}/pylons/recipe/${cookbook_id}/${recipe_id}`;
+
             try { 
-                let response = HTTP.get(Meteor.settings.remote.api);
+                let response = HTTP.get(recipesUrl);
                 //selectedItem = JSON.parse(response.content).CompletedExecutions;   
-                recipes = JSON.parse(response.content).Recipes;   
+                selectedRecipe = JSON.parse(response.content).Recipe;
                 
             } catch (e) { 
                 console.log(e);
-            }    
-            for(i = 0; i < recipes.length; i++){
-                selectedRecipe = recipes[i];
-                if(selectedRecipe.ID == recipe_id){
-                    break;
-                }
             }
             
             if (selectedRecipe != undefined && selectedRecipe != null && selectedRecipe.entries.itemOutputs.length > 0) {                 

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -58,7 +58,7 @@ Meteor.startup(() => {
         if (querys['?action'] == "purchase_nft" && querys['recipe_id'] != null && querys['cookbook_id'] != null && querys['nft_amount'] == 1) { 
             var selectedItem = null; 
             const recipe_id = querys['recipe_id']    
-            let recipesUrl = API + 'pylons/recipes/'    
+            let recipesUrl = Meteor.settings.remote.api + '/pylons/recipes/'
 
             try { 
                 let response = HTTP.get(recipesUrl);    
@@ -229,7 +229,7 @@ Meteor.startup(() => {
             const recipe_id = querys['recipe_id']   
             //const cookbook_id = querys['cookbook_id']     
             try { 
-                let response = HTTP.get(API); 
+                let response = HTTP.get(Meteor.settings.remote.api);
                 //selectedItem = JSON.parse(response.content).CompletedExecutions;   
                 recipes = JSON.parse(response.content).Recipes;   
                 

--- a/imports/ui/home/Home.jsx
+++ b/imports/ui/home/Home.jsx
@@ -34,7 +34,7 @@ export default class Home extends Component{
 
     render() {  
         if(this.state.recipeExist){ 
-           return  <EaselBuy recipe_id={this.state.recipe_id} url={'http://wallet.pylons.tech/' + this.props.location.search}></EaselBuy>
+           return  <EaselBuy recipe_id={this.state.recipe_id} url={Meteor.settings.public.baseURL + "/" + this.props.location.search}></EaselBuy>
         }
         else{
             return <div id="home">


### PR DESCRIPTION
## Description
When sharing link from Easel NFT image link is not valid as a text in Discord or Text message invalid image for NFT- As of now there is 2021 Team of the Year image with Fifa Team.

Fixes #
- Changed hard codded urls and made them dynamic from settings.json
- Changed API for getting receipes to get single recipe instead of all recipes

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Run `meteor npm run lint`
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
