### PR TITLE
Fix: redirect URL was replaced with deep link

### DIFF
--- a/imports/ui/easel_buy/EaselBuy.jsx
+++ b/imports/ui/easel_buy/EaselBuy.jsx
@@ -111,10 +111,14 @@ export default class EaselBuy extends Component {
     );
   }
 
+
+  // In case IOS will redirect to APP Store if app not installed
+  // In case Android will redirect to Play store if app not installed
+  // In case in Browser will redirect to Play store
   handleLoginConfirmed = (success) => {
     if (success) {
       window.location =
-        "https://play.google.com/store/apps/details?id=tech.pylons.wallet&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1";
+        "https://pylons.page.link/edXKuEX1vC4tjBUD9";
     }
   };
 


### PR DESCRIPTION
Resolved [https://pylonstech.atlassian.net/browse/PS-197](url)
Resolved [https://pylonstech.atlassian.net/browse/PS-198](url)
## Description
On NFT buy, deep link was added to move to specific platform
In case IOS will redirect to APP Store if app not installed
In case Android will redirect to Play store if app not installed
In case in Browser will redirect to Play store
Fixes #
- handleLoginConfirmed was updated to deep link
## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Run `meteor npm run lint`
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
