### PR TITLE
Added apple-app-site-association File in Public Folder

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,14 @@
+{
+	"applinks": {
+		"details": [{
+			"appIDs": ["QV67PMQ8H3.xyz.pylons.wallet"],
+			"components": [{
+				"/": "*",
+				"comment": ""
+			}]
+		}]
+	},
+	"webcredentials": {
+		"apps": ["QV67PMQ8H3.xyz.pylons.wallet"]
+	}
+}


### PR DESCRIPTION
## Description
Add apple-app-site-association of .well-known folder in public folder to make it accessible for apple universal link verification  
Fixes #
- added apple-app-site-association file in public folder

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Run `meteor npm run lint`
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
